### PR TITLE
feat: proxy url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ DEVELOPER_ID=00000 # Please replace with your Developer-ID
 #PATH_CERTIFICATE=/path/to/certificate/your.pfx # Optional [default: "certificate/test-softorg-pse.pfx"]
 #PATH_DOWNLOAD=/path/to/download # Optional [default: "."]
 #PATH_LOG=/path/to/log # Optional [default: "."]
+#PROXY_URL=http://my.pro.xy:1234 # Optional [default: null]
 
 # Warning:
 #  Docker interprets double quotes " literally, use single quotes ' instead.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This demo intends to simplify the transition and reduce implementation time.
   -m size               Allocate provided Bytes of memory and download object in-memory (optional, max: 10485760 Bytes), cf. Download modes
   -e extension          Set filename extension of downloaded content [default: "txt"]
   -p password           Password for certificate [default: "123456"]
+  -y proxy              Proxy URL for communucation with the OTTER server (optional, by default no proxy is being set within Otto)
   -f                    Force file overwriting [default: false]
 ```
 
@@ -51,7 +52,7 @@ You need the official ELSTER Otto library. Download the ERiC package >= v40 for 
 > The ERiC package, especially the included there libraries are subject to a separate license agreement (presented before download in the ELSTER developer area and included in the ERiC package itself).
 
 > [!TIP]  
-> Choose the right library for the platform you compile and run on. Recommended ERiC version to use: 41.2
+> Choose the right library for the platform you compile and run on. Recommended Otto version to use: 41.2 with eSigner 60.0.1.2
 
 ## Build with Docker
 

--- a/csotto.cs
+++ b/csotto.cs
@@ -331,7 +331,7 @@ internal static class Native
     [DllImport("otto", CallingConvention = CallingConvention.StdCall)]
     public static extern OttoStatusCode OttoProxyKonfigurationSetzen(
         IntPtr instanz,
-        OttoProxyKonfiguration proxyKonfiguration);
+        [MarshalAs(UnmanagedType.LPStruct)] OttoProxyKonfiguration proxyKonfiguration);
 
     [DllImport("otto", CallingConvention = CallingConvention.StdCall)]
     public static extern OttoStatusCode OttoEmpfangBeginnen(
@@ -429,7 +429,6 @@ internal static class Program
             Console.Error.WriteLine(" -p password\t\tPassword for certificate [default: \"123456\"]");
             Console.Error.WriteLine(" -y proxy\t\tProxy URL for communucation with the OTTER server (optional, by default no proxy is being set within Otto)");
             Console.Error.WriteLine(" -f\t\t\tForce file overwriting [default: false]");
-            Console.Error.WriteLine(" -o\t\t\tSpecify Url of the proxy server Otto should use");
             return (int)CsottoReturnCode.TOO_FEW_ARGUMENTS;
         }
 
@@ -466,9 +465,6 @@ internal static class Program
                     break;
                 case "-f":
                     forceOverwrite = true;
-                    break;
-                case "-o":
-                    proxyUrl = args[++i];
                     break;
                 default:
                     Console.Error.WriteLine("Unsupported option: " + args[i]);

--- a/csotto.cs
+++ b/csotto.cs
@@ -44,9 +44,9 @@ internal class CsottoBlockwise : IDisposable
         }
 
         // Set proxy
-        if (proxyUrl != null)
+        if (!string.IsNullOrEmpty(proxyUrl))
         {
-            OttoStatusCode statusCodeProxy = Native.OttoProxyKonfigurationSetzen(instance, new OttoProxyKonfiguration { url = proxyUrl, version = 1 });
+            OttoStatusCode statusCodeProxy = Native.OttoProxyKonfigurationSetzen(instance, new OttoProxyKonfiguration { version = 1, url = proxyUrl });
             if (statusCodeProxy != OttoStatusCode.OTTO_OK)
             {
                 Common.Error("Could not set proxy configuration. Check otto.log for details.", statusCodeProxy);
@@ -202,9 +202,9 @@ internal class CsottoInMemory : IDisposable
         }
 
         // Set proxy
-        if (proxyUrl != null)
+        if (!string.IsNullOrEmpty(proxyUrl))
         {
-            OttoStatusCode statusCodeProxy = Native.OttoProxyKonfigurationSetzen(instance, new OttoProxyKonfiguration { url = proxyUrl, version = 1 });
+            OttoStatusCode statusCodeProxy = Native.OttoProxyKonfigurationSetzen(instance, new OttoProxyKonfiguration { version = 1, url = proxyUrl });
             if (statusCodeProxy != OttoStatusCode.OTTO_OK)
             {
                 Common.Error("Could not set proxy configuration. Check otto.log for details.", statusCodeProxy);
@@ -427,6 +427,7 @@ internal static class Program
             Console.Error.WriteLine(" -m size\t\tAllocate provided Bytes of memory and download object in-memory (optional, max: 10485760 Bytes), when not provided or exceeds max download blockwise");
             Console.Error.WriteLine(" -e extension\t\tSet filename extension of downloaded content [default: \"txt\"]");
             Console.Error.WriteLine(" -p password\t\tPassword for certificate [default: \"123456\"]");
+            Console.Error.WriteLine(" -y proxy\t\tProxy URL for communucation with the OTTER server (optional, by default no proxy is being set within Otto)");
             Console.Error.WriteLine(" -f\t\t\tForce file overwriting [default: false]");
             Console.Error.WriteLine(" -o\t\t\tSpecify Url of the proxy server Otto should use");
             return (int)CsottoReturnCode.TOO_FEW_ARGUMENTS;
@@ -460,6 +461,9 @@ internal static class Program
                 case "-p":
                     certificatePassword = args[++i];
                     break;
+                case "-y":
+                    proxyUrl = args[++i];
+                    break;
                 case "-f":
                     forceOverwrite = true;
                     break;
@@ -467,7 +471,7 @@ internal static class Program
                     proxyUrl = args[++i];
                     break;
                 default:
-                    Console.Error.WriteLine("Unsupported option: -" + args[i]);
+                    Console.Error.WriteLine("Unsupported option: " + args[i]);
                     return (int)CsottoReturnCode.UNSUPPORTED_ARGUMENT;
             }
         }
@@ -511,6 +515,10 @@ internal static class Program
 
         string pathCertificate = Environment.GetEnvironmentVariable("PATH_CERTIFICATE") ?? "certificate/test-softorg-pse.pfx";
         string pathLog = Environment.GetEnvironmentVariable("PATH_LOG") ?? ".";
+        if (string.IsNullOrEmpty(proxyUrl))
+        {
+            proxyUrl = Environment.GetEnvironmentVariable("PROXY_URL") ?? null;
+        }
 
         if (memorySizeAllocation is > 0 and <= 10485760)
         {


### PR DESCRIPTION
- Add option `-y` for setting a proxy url to use while communicating with the OTTER servers
- Add `PROXY_URL` environment variable (`-y` overrides it)

> [!NOTE]  
> By default no proxy is being used within Otto.